### PR TITLE
Use devel version of covr, fix option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ notifications:
 
 #after_success
 after_success:
-    - Rscript -e "covr::codecov(excludes = 'src/sqlite3/sqlite3.c')"
+    - Rscript -e "covr::codecov(line_exclusions = 'src/sqlite3/sqlite3.c')"
     #- R -q -e 'tic::after_success()'
       #- Rscript -e "source ('https://install-github.me/MangoTheCat/goodpractice')"
       #- Rscript -e 'library(goodpractice);gp(checks=all_checks()[grepl("(rcmdcheck|covr)",all_checks())])'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,8 @@ Suggests:
     knitr,
     rmarkdown,
     roxygen2,
-    testthat
+    testthat,
+    covr
 LinkingTo: 
     BH,
     Rcpp
@@ -33,3 +34,4 @@ BugReports: https://github.com/mpadge/bikedata/issues
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1
+Remotes: jimhester/covr


### PR DESCRIPTION
Because this package uses C++11 covr needs to set a compiler flags to
turn on coverage. Prior to R-3.4 this option was called CXX1XFLAGS,
however from R-3.4 and on it is called CXX11FLAGS. The CRAN version of
covr only sets CXX1XFLAGS, so C++11 code doesn't get the `--coverage`
flag to turn on coverage tracking, which is why you were not getting
code coverage results.